### PR TITLE
Fix typo encodeURIComponent [es]

### DIFF
--- a/files/es/web/javascript/reference/global_objects/encodeuricomponent/index.md
+++ b/files/es/web/javascript/reference/global_objects/encodeuricomponent/index.md
@@ -96,7 +96,7 @@ function encodeRFC3986URIComponent(str) {
 
 ### Codificación de un sustituto solitario lanza
 
-Un {{jsxref("URIError")}} será lanaado si se intenta codificar un sustituto que no es parte de un par alto-bajo. Por ejemplo:
+Un {{jsxref("URIError")}} será lanzado si se intenta codificar un sustituto que no es parte de un par alto-bajo. Por ejemplo:
 
 ```js
 // El par alto-bajo está bien


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description


Fix typo introduced after pr accepted


### Related issues and pull requests


Relates to #24099

